### PR TITLE
Fix line lengths to be max 88 chars to comply with linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/hfoote/snapAnalysis"
 Issues = "https://github.com/hfoote/snapAnalysis/issues"
+
+[tool.ruff.lint]
+select = ["E", "F"]

--- a/snapAnalysis/sim.py
+++ b/snapAnalysis/sim.py
@@ -25,11 +25,11 @@ def orbit_com(
     out_file : None or str, optional
             if not None, saves the orbit file under this name
     select_IDs : None or tuple, optional
-            min. and max. particle IDs for selection if desired, otherwise uses all particles
-            of the specified type.
+            min. and max. particle IDs for selection if desired, otherwise uses all 
+            particles of the specified type.
     use_guess : None or str ('previous')
-            specifies where the intial sphere is centered. None uses the com of every particle,
-            'previous' uses the previous snapshot's com.
+            specifies where the intial sphere is centered. None uses the com of 
+            every particle, 'previous' uses the previous snapshot's com.
     com_kwargs : dict, optional
             kwargs for snap.find_position_center, by default {}
     vel_kwargs : dict, optional

--- a/snapAnalysis/snap.py
+++ b/snapAnalysis/snap.py
@@ -1,4 +1,5 @@
-# Contains the main snaphot class of snapAnalysis, which stores snapshots in a flexible format.
+# Contains the main snaphot class of snapAnalysis, which stores snapshots in a 
+# flexible format.
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -14,8 +15,9 @@ from scipy.spatial import KDTree
 
 
 class snapshot:
-    """The main class of snapAnalysis, which reads and stores a single particle type from a single gagdet/arepo format hdf5 snapshot.
-    Methods provide common analysis routines such as computing density fields, centering, rotations, etc.
+    """The main class of snapAnalysis, which reads and stores a single particle type 
+    from a single gagdet/arepo format hdf5 snapshot. Methods provide common analysis 
+    routines such as computing density fields, centering, rotations, etc.
     """
 
     def __init__(self, filename: str, ptype: int) -> None:
@@ -108,7 +110,8 @@ class snapshot:
                 head = f["Header"]
             except KeyError:
                 print(
-                    "Either the header does not have the name 'Header' or it does not exist."
+                    "Either the header does not have the name 'Header' or it does \
+                        not exist."
                 )
                 raise
             # print each key and what it contains
@@ -164,7 +167,8 @@ class snapshot:
         return masstable
 
     def check_if_field_read(self, field: str) -> bool:
-        """check_if_field_read checks to see whether a data field has already been stored
+        """check_if_field_read checks to see whether a data field has 
+        already been stored
 
         Parameters
         ----------
@@ -183,8 +187,9 @@ class snapshot:
         return True
 
     def arrange_fields(self, indices: np.ndarray) -> None:
-        """arrange_fields re-arranges all existing data fields according to the input indices.
-        Useful for sorting the simulation by particle ID, for instance.
+        """arrange_fields re-arranges all existing data fields according 
+        to the input indices. Useful for sorting the simulation by particle ID, 
+        for instance.
 
         Parameters
         ----------
@@ -219,13 +224,15 @@ class snapshot:
         self.subset = True
 
     def load_particle_data(self, fields: list) -> None:
-        """load_particle_data reads particle data for a field if it doesn't already exist
+        """load_particle_data reads particle data for a field if it doesn't 
+        already exist.
 
         Parameters
         ----------
         fields : list
                 list containing desired data fields, e.g.
-                ['Coordinates', 'Velocities', 'ParticleIDs', 'Masses', 'Potential', 'Acceleration', 'PsiRe', 'PsiIm']
+                ['Coordinates', 'Velocities', 'ParticleIDs', 'Masses', 'Potential', \\
+                'Acceleration', 'PsiRe', 'PsiIm']
         """
 
         for field in fields:
@@ -243,7 +250,7 @@ class snapshot:
             if (field == "Velocity") and (self.ptype == 1) and self.fdm:
                 self.data_fields[field] = self.get_FDM_velocities()
 
-            # special case for masses, populate mass array from masstable or wavefunction if necessary
+            # populate mass array from masstable or wavefunction if necessary
             if field == "Masses":
                 if (self.ptype == 1) and self.fdm:
                     self.data_fields[field] = (
@@ -270,7 +277,8 @@ class snapshot:
                 )
 
     def get_FDM_velocities(self) -> None:
-        """Calculates the FDM velocity field based on the wavefunction outputs, via the phase gradient method:
+        """Calculates the FDM velocity field based on the wavefunction outputs, 
+        via the phase gradient method:
         v = hbar/m gradient(phase). Based on code from Philip Mocz
         """
 
@@ -339,7 +347,8 @@ class snapshot:
     def apply_center(
         self, pos_center: np.ndarray, vel_center: np.ndarray | None = None
     ) -> None:
-        """center_particles centers particles on a specified center in position and velocity
+        """center_particles centers particles on a specified center 
+        in position and velocity
 
         Parameters
         ----------
@@ -371,16 +380,20 @@ class snapshot:
         N_min: int = 1000,
         verbose: bool = False,
     ) -> np.ndarray:
-        """find_position_center finds the center of mass of the snapshot via the shrinking-spheres method.
+        """find_position_center finds the center of mass of the snapshot via 
+        the shrinking-spheres method.
 
         Parameters
         ----------
         guess : None or np.ndarray, optional
-                Initial [x,y,z] guess for COM position. If None, uses the com of every active particle in the box.
+                Initial [x,y,z] guess for COM position. If None, uses the com of 
+                every active particle in the box.
         r_start : None or float, optional
-                Initial sphere radius, default (none) uses furthest particle from box origin
+                Initial sphere radius, default (none) uses furthest particle from 
+                box origin
         vol_dec : float, optional
-                Factor by which the sphere radius is reduced during an iteration, by default 3.
+                Factor by which the sphere radius is reduced during an iteration, 
+                by default 3.
         delta : float, optional
                 Tolerance, stop when change in COM is less than delta, by default 0.01
         Nmin : int, optional
@@ -423,7 +436,7 @@ class snapshot:
         i = 0
 
         while change > delta:
-            # all particles within the reduced radius, starting from original coordinates
+            # all particles within the reduced radius, in original coordinates
             index2 = np.where(r_new <= r_max)
             pos2 = self.data_fields["Coordinates"][index2]
             m2 = self.data_fields["Masses"][index2]
@@ -465,7 +478,8 @@ class snapshot:
         pos_center : np.ndarray
                 [x, y, z] center of mass position
         r_max : u.Quantity, optional
-                max distance from COM to use particles for the calculation, by default 15.0*u.kpc
+                max distance from COM to use particles for the calculation, 
+                by default 15.0*u.kpc
 
         Returns
         -------
@@ -488,7 +502,8 @@ class snapshot:
         self, com_kwargs: dict = {}, vel_kwargs: dict = {}
     ) -> None:
         """find_and_apply_center Calculates the positions and velocity center
-        of the snapshot and centers the particle data on the COM location in phase-space.
+        of the snapshot and centers the particle data on the COM location 
+        in phase-space.
 
         Parameters
         ----------
@@ -529,13 +544,14 @@ class snapshot:
     def find_angular_momentum_direction(
         self, r_max: u.Quantity | None = None
     ) -> np.ndarray:
-        """find_angular_momentum_direction Returns the normalized average specific angular momentum vector of
-        the loaded particles.
+        """find_angular_momentum_direction Returns the normalized average 
+        specific angular momentum vector of the loaded particles.
 
         Parameters
         ----------
         r_max : u.Quantity | None, optional
-                max. radius within which to consider particles. None uses entire box. By default None
+                max. radius within which to consider particles. None uses entire box. 
+                By default None
 
         Returns
         -------
@@ -580,8 +596,8 @@ class snapshot:
         slice_width: None | float = None,
         normalization: bool = "surface",
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """density_projection generates a density histogram projected along the specified
-        axis.
+        """density_projection generates a density histogram projected along 
+        the specified axis.
 
         Parameters
         ----------
@@ -731,22 +747,23 @@ class snapshot:
         """density_points computes the local density field at a specified collection of
         points using the k_max-th nearest particles to the point.
 
-        In practice, the density at a local point is calculated as the mass of k_max particles,
-        divided by the volume of a sphere with radius equal to the distance to the k_max-th
-        nearest-neighbor.
+        In practice, the density at a local point is calculated as the mass of 
+        k_max particles, divided by the volume of a sphere with radius equal to the 
+        distance to the k_max-th nearest-neighbor.
 
         Parameters
         ----------
         points : np.ndarray
                 Nx3 array of points at which to compute the density
         k_max : int, optional
-                maximum nearest neighbor to use in density calculation, i.e. the defualt of 1000
-                uses the 1000 nearest-neighbors.
+                maximum nearest neighbor to use in density calculation, i.e. 
+                the defualt of 1000 uses the 1000 nearest-neighbors.
 
         Returns
         -------
         np.ndarray
-                Array of length N containing the value of the density field at the input points
+                Array of length N containing the value of the density field at the 
+                input points
         """
 
         self.load_particle_data(["Coordinates", "Masses"])
@@ -775,8 +792,8 @@ class snapshot:
         plot: bool = True,
         plot_name: bool | str = False,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """anisotropy_profile calculates the velocity anisotropy profile of a halo, given by
-        Eqn 4.61 of Binney & Tremaine
+        """anisotropy_profile calculates the velocity anisotropy profile of a halo, 
+        given by Eqn 4.61 of Binney & Tremaine
 
         Parameters
         ----------
@@ -787,7 +804,8 @@ class snapshot:
         nbins : int, optional
                 number of radial bins, by default 100
         log_bins : bool, optional
-                If True, make logarithmically spaced bins instead of linearly spaced bins, by default False
+                If True, make logarithmically spaced bins instead of linearly 
+                spaced bins, by default False
         plot : bool, optional
                 show a plot of the computed profile, by default True
         plot_name : bool | str, optional
@@ -803,7 +821,8 @@ class snapshot:
 
         if (not self.pos_centered) | (not self.vel_centered):
             warnings.warn(
-                "Snapshot has not been centered! Calculating an anisotropy profile on an un-centered snapshot may give garbage results."
+                "Snapshot has not been centered! Calculating an anisotropy profile on \
+                    an un-centered snapshot may give garbage results."
             )
 
         self.load_particle_data(["Coordinates", "Velocities"])
@@ -865,21 +884,24 @@ class snapshot:
         plot_name: bool | str = False,
         slice_width: None | float = None,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """potential_projection bins the particles in the specified plane and finds the mean value of the potential within each bin.
+        """potential_projection bins the particles in the specified plane and finds 
+        the mean value of the potential within each bin.
 
         Parameters
         ----------
         axis : int, optional
                 Axis to project along (x=0, y=1, z=2), by default 2
         bins : int | list, optional
-                bin specification passed to scipy's binned_statistic_2d, by default [200,200]
+                bin specification passed to scipy's binned_statistic_2d, 
+                by default [200,200]
         plot : bool, optional
                 create a plot of the potential, by default True
         plot_name : bool | str, optional
                 if not False, saves the plot under this file name, by default False
         slice_width : None | float, optional
-                Leave as None to use the whole box. Otherwise, provide a distance in the length units of the snapshot
-        from the midplane along the specified axis to include, by default None
+                Leave as None to use the whole box. Otherwise, provide a distance 
+                in the length units of the snapshot from the midplane along the 
+                specified axis to include, by default None
 
         Returns
         -------

--- a/snapAnalysis/utils.py
+++ b/snapAnalysis/utils.py
@@ -180,7 +180,8 @@ def cartesian_to_cylindrical(coords: np.ndarray) -> np.ndarray:
 
 def rotation_matrix(alpha: float, beta: float, gamma: float) -> np.ndarray:
     """rotation_matrix returns the rotation matrix for a general intrinsic rotation
-    of yaw, pitch, roll (Tait-Bryan angles about z,y,x) alpha, beta, gamma, respectively.
+    of yaw, pitch, roll (Tait-Bryan angles about z,y,x) alpha, beta, gamma, 
+    respectively.
 
     Parameters
     ----------

--- a/tests/snap_unit_test.py
+++ b/tests/snap_unit_test.py
@@ -37,7 +37,9 @@ def test_can_read_metadata(snap, expected, request):
 
 def test_unit_detection(dm_snap):
     print(dm_snap)
-    unit_tol = 1e-3  # 1 part in 1000 should account for rounding differences between unit specification in astropy vs gadget
+     # define tolerance - 1 part in 1000 should account for rounding differences 
+     # between unit specification in astropy vs gadget
+    unit_tol = 1e-3 
     assert (dm_snap.field_units["Coordinates"] - 1.0 * u.kpc) / (
         1.0 * u.kpc
     ) < unit_tol, "Length unit detection failed!"

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -21,9 +21,10 @@ def test_orbit_com():
         ]
     )
 
-    # A user wants to determine the COM position and velocity of the dark matter halo in
-    # the test simulation contained in tests/example_snaps.
-    # They specify a shrinking factor of 2, and save the COM data in a file called test_centers.txt
+    # A user wants to determine the COM position and velocity of the dark matter 
+    # halo in the test simulation contained in tests/example_snaps.
+    # They specify a shrinking factor of 2, and save the COM data in a 
+    # file called test_centers.txt
     test_file = "tests/test_centers.txt"
     orbit = orbit_com(
         "tests/example_snaps/", 1, com_kwargs={"vol_dec": 2.0}, out_file=test_file
@@ -31,8 +32,8 @@ def test_orbit_com():
 
     assert np.allclose(orbit, TEST_ARR), "Orbit determination failed!"
 
-    # Later, they want to use the stored centers, so they load the orbit file they saved earlier,
-    # and compare it to the output from the center finder.
+    # Later, they want to use the stored centers, so they load the orbit file 
+    # they saved earlier, and compare it to the output from the center finder.
     orbit_from_file = np.loadtxt(test_file)
 
     assert np.allclose(orbit_from_file, TEST_ARR), "Orbit file failed!"


### PR DESCRIPTION
Add ruff rules E and F to config in pyproject.toml, and fix line widths in the package to be compatible with the imposed 88-character limit. 