### PR TITLE
Vector field transforms

### DIFF
--- a/src/snapanalysis/utils.py
+++ b/src/snapanalysis/utils.py
@@ -122,12 +122,12 @@ def cartesian_to_spherical(coords: np.ndarray) -> np.ndarray:
     Parameters
     ----------
     coords : np.array
-            Nx3 array of x,y,z coordinates
+        Nx3 array of x,y,z coordinates
 
     Returns
     -------
     np.array
-            (r, theta (polar), phi (azimuth)) coordinates
+        (r, theta (polar), phi (azimuth)) coordinates
     """
 
     # make input 2D if required
@@ -210,7 +210,7 @@ def cartesian_to_cylindrical(coords: np.ndarray) -> np.ndarray:
     Returns
     -------
     np.array
-            (rho, phi (azimuth), z) coordinates
+        (rho, phi (azimuth), z) coordinates
     """
 
     # make input 2D if required
@@ -227,6 +227,47 @@ def cartesian_to_cylindrical(coords: np.ndarray) -> np.ndarray:
         return np.hstack([rho, phi, coords[:, 2]])
 
     return np.array([rho, phi, coords[:, 2]]).T
+
+
+def vector_cartesian_to_cylindrical(coords: np.ndarray, vecs: np.ndarray) -> np.ndarray:
+    '''vector_cartesian_to_cylindrical transforms a vector field defined in 
+    cartesian coordinates at coords with vectors vecs into cylindrical coordinates.
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        Points at which the vector field is defined in Cartesian coordinates
+    vecs : np.ndarray
+        Cartesian vector values of the field
+
+    Returns
+    -------
+    np.ndarray
+        (rho, phi (azimuth), z) vectors
+    '''
+
+    # make inputs 2D if required
+    if coords.ndim == 1:
+        coords = coords[np.newaxis, :]
+        vecs = vecs[np.newaxis, :]
+        remove_axis = True
+    else:
+        remove_axis = False
+
+    coords_cylindrical = cartesian_to_cylindrical(coords)
+    phi = coords_cylindrical[:,1]
+
+    vx = vecs[:,0]
+    vy = vecs[:,1]
+    vz = vecs[:,2]
+
+    v_rho = (np.cos(phi)*vx + np.sin(phi)*vy)
+    v_phi = (-np.sin(phi)*vx + np.cos(phi)*vy)
+
+    if remove_axis:
+        return np.hstack([v_rho, v_phi, vz])
+
+    return np.array([v_rho, v_phi, vz]).T
 
 
 def rotation_matrix(alpha: float, beta: float, gamma: float) -> np.ndarray:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,3 +137,30 @@ def test_vector_cartesian_to_spherical(input_points, input_vectors, expected) ->
     ), "Spherical vector transform failed!"
 
     return None
+
+@pytest.mark.parametrize(
+    "input_points, input_vectors, expected", 
+    [
+        (
+            np.array([0.5, 0.5, 1.]), 
+            np.array([0., 0., 1.]), 
+            np.array([0., 0., 1.])
+        ),
+        (
+            np.array([[0.5, 0.5, 1.],
+                     [1., 0., 0.]]), 
+            np.array([[0., 0., 1.],
+                     [1., 0., 0.]]), 
+            np.array([[0., 0., 1.],
+                     [1., 0., 0.]])
+        )
+    ]
+)
+def test_vector_cartesian_to_cylindrical(input_points, input_vectors, expected) -> None:
+    from snapanalysis.utils import vector_cartesian_to_cylindrical
+
+    assert np.allclose(
+        vector_cartesian_to_cylindrical(input_points, input_vectors), expected
+    ), "Cylindrical vector transform failed!"
+
+    return None


### PR DESCRIPTION
Add coordinate transformations for vector fields from cartesian to cylindrical and spherical coordinates. Useful for transforming velocity and acceleration fields into commonly-used coordinate frames for visualization. 