### PR TITLE
Inertia tensor

### DIFF
--- a/src/snapanalysis/snap.py
+++ b/src/snapanalysis/snap.py
@@ -600,6 +600,24 @@ class snapshot:
         mat = utils.find_alignment_rotation(J.value)
         self.apply_rotation(mat)
 
+    def principal_axes(self) -> tuple[np.ndarray, np.ndarray]:
+        '''principal_axes calculates the length and direction of the principal
+        axes of the particle distribution by diagonalizing the inertia tensor.
+
+        Returns
+        -------
+        np.ndarray
+            Principal axes lengths (eigenvalues of inertia tensor)
+        np.ndarray
+            Principal axes directions (eigenvectors of inertia tensor)
+        '''
+        self.load_particle_data(["Masses", "Coordinates"])
+        inertia_tensor = utils.inertia_tensor(
+            self.data_fields["Masses"].value, 
+            self.data_fields["Coordinates"].value
+        )
+        return np.linalg.eig(inertia_tensor)
+
     def density_projection(
         self,
         axis: int = 2,

--- a/src/snapanalysis/utils.py
+++ b/src/snapanalysis/utils.py
@@ -332,3 +332,33 @@ def find_alignment_rotation(vec: np.ndarray) -> np.ndarray:
     _, theta, phi = cartesian_to_spherical(vec)
 
     return rotation_matrix(-phi, -theta, 0.0)
+
+
+def inertia_tensor(m: np.ndarray, pos: np.ndarray) -> np.ndarray:
+    '''inertia_tensor Calculates the inertia tensor for a collection
+    of point masses of mass m at positions pos
+
+    Parameters
+    ----------
+    m : np.ndarray
+        Nx1 array of masses
+    pos : np.ndarray
+        Nx3 array of positions
+
+    Returns
+    -------
+    np.ndarray
+        3x3 symmetric inertia tensor
+    '''
+
+    I = np.zeros([3, 3])
+
+    I[0,0] = np.sum(m * (pos[:,1]**2 + pos[:,2]**2))
+    I[1,1] = np.sum(m * (pos[:,0]**2 + pos[:,2]**2))
+    I[2,2] = np.sum(m * (pos[:,0]**2 + pos[:,1]**2))
+
+    I[0,1] = I[1,0] = - np.sum(m * pos[:,0] * pos[:,1])
+    I[0,2] = I[2,0] = - np.sum(m * pos[:,0] * pos[:,2])
+    I[1,2] = I[2,1] = - np.sum(m * pos[:,1] * pos[:,2])
+
+    return I

--- a/src/snapanalysis/utils.py
+++ b/src/snapanalysis/utils.py
@@ -351,14 +351,14 @@ def inertia_tensor(m: np.ndarray, pos: np.ndarray) -> np.ndarray:
         3x3 symmetric inertia tensor
     '''
 
-    I = np.zeros([3, 3])
+    inertia_tensor = np.zeros([3, 3])
 
-    I[0,0] = np.sum(m * (pos[:,1]**2 + pos[:,2]**2))
-    I[1,1] = np.sum(m * (pos[:,0]**2 + pos[:,2]**2))
-    I[2,2] = np.sum(m * (pos[:,0]**2 + pos[:,1]**2))
+    inertia_tensor[0,0] = np.sum(m * (pos[:,1]**2 + pos[:,2]**2))
+    inertia_tensor[1,1] = np.sum(m * (pos[:,0]**2 + pos[:,2]**2))
+    inertia_tensor[2,2] = np.sum(m * (pos[:,0]**2 + pos[:,1]**2))
 
-    I[0,1] = I[1,0] = - np.sum(m * pos[:,0] * pos[:,1])
-    I[0,2] = I[2,0] = - np.sum(m * pos[:,0] * pos[:,2])
-    I[1,2] = I[2,1] = - np.sum(m * pos[:,1] * pos[:,2])
+    inertia_tensor[0,1] = inertia_tensor[1,0] = - np.sum(m * pos[:,0] * pos[:,1])
+    inertia_tensor[0,2] = inertia_tensor[2,0] = - np.sum(m * pos[:,0] * pos[:,2])
+    inertia_tensor[1,2] = inertia_tensor[2,1] = - np.sum(m * pos[:,1] * pos[:,2])
 
-    return I
+    return inertia_tensor

--- a/tests/snap_unit_test.py
+++ b/tests/snap_unit_test.py
@@ -113,3 +113,9 @@ def test_density_points_returns_correct_central_density(dm_snap):
     emp_density = (dm_snap.data_fields['Masses'][0] * k / volume).value
 
     assert np.abs(central_density/emp_density - 1) < 1e-6
+
+
+def test_halo_axis_ratios_are_similar(dm_snap):
+    axis_ratios, principal_axes = dm_snap.principal_axes()
+
+    assert np.all(np.abs(axis_ratios/axis_ratios.max() - 1) < 0.2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -174,3 +174,25 @@ def test_vector_cartesian_to_cylindrical(input_points, input_vectors, expected) 
     ), "Cylindrical vector transform failed!"
 
     return None
+
+
+def test_inertia_tensor_for_point_masses() -> None:
+    from snapanalysis.utils import inertia_tensor
+
+    input_pos = np.array([
+        [-1., 0., 0.],
+        [1., 0., 0.],
+        [0, -1., 2.]
+    ])
+    input_m = np.array([1., 2., 1.])
+
+    expected = np.array([
+        [5., 0., 0.],
+        [0., 7., 2.],
+        [0., 2., 4.]
+    ])
+
+    assert np.allclose(
+        inertia_tensor(input_m, input_pos), expected
+    ), "Inertia tensor calculation failed!"
+


### PR DESCRIPTION
Add an inertia tensor-based calculator of principal axes.

Todo: add a radius cutoff in tests/snap_unit_test.py: test_halo_axis_ratios_are_similar() to make the low-N particle distribution more spherical.