### PR TITLE
Add particle orbit extraction

### DIFF
--- a/src/snapanalysis/orbit.py
+++ b/src/snapanalysis/orbit.py
@@ -1,0 +1,80 @@
+# Defines snapAnalysis' Orbit dataclass for storing orbits of individual particles
+
+from dataclasses import dataclass
+import numpy as np
+from astropy.units import Quantity
+import pickle
+
+
+@dataclass(eq=False)
+class Orbit:
+    """Stores orbits of particles throughout a simulation.
+    TODO: allow adding of orbits
+
+    Attributes
+    ----------
+    t : np.array of astropy.Quantity
+            Times the orbit is recorded at
+    pos : np.array of astropy.Quantity
+            Orbit xyz positions, shape is (N_times, 3, N_particles)
+    vel : np.array of astropy.Quantity
+            Orbit xyz positions, shape is (N_times, 3, N_particles)
+    ids : dict
+            Keys are particle IDs, values are the index of the particles in the
+            last dimension of the position and velocity arrays
+    source : str, optional
+            The directory of the simulation the orbit was extracted from
+    """
+
+    t: np.ndarray[Quantity]
+    pos: np.ndarray[Quantity]
+    vel: np.ndarray[Quantity]
+    ids: dict
+    source_dir: str | None = None
+
+    def __eq__(self, other_obj: object) -> bool:
+        """
+        Returns True if the contents of the other Orbit object are identical
+        """
+        if isinstance(other_obj, Orbit):
+            return (
+                np.array_equal(self.t, other_obj.t)
+                and np.array_equal(self.pos, other_obj.pos)
+                and np.array_equal(self.vel, other_obj.vel)
+                and self.ids == other_obj.ids
+                and self.source_dir == other_obj.source_dir
+            )
+        return False
+
+    def save(self, filename: str):
+        """
+        Saves the Orbit object to a pickle binary file
+
+        Parameters
+        ----------
+        filename : str
+                name of the file
+        """
+        with open(filename, "wb") as f:
+            pickle.dump(self, f)
+
+
+def read_orbit_from_file(filename: str) -> Orbit:
+    """
+    Reads an Orbit object from a pickle binary file
+
+    Parameters
+    ----------
+    filename : str
+            name of the file
+
+    Returns
+    -------
+    snapanalysis.orbit.Orbit
+            Loaded Orbit object
+    """
+
+    with open(filename, "rb") as f:
+        orb = pickle.load(f)
+
+    return orb

--- a/src/snapanalysis/sim.py
+++ b/src/snapanalysis/sim.py
@@ -1,8 +1,12 @@
 # Routines for analyzing an entire simulation at once
+# TODO: wrapper routine for multiprocessing
+# TODO: function for storing rotation matrices
 
 import numpy as np
 from .snap import snapshot
 from .utils import get_snaps
+from .orbit import Orbit
+
 
 def orbit_com(
     sim_dir: str,
@@ -25,10 +29,10 @@ def orbit_com(
     out_file : None or str, optional
             if not None, saves the orbit file under this name
     select_IDs : None or tuple, optional
-            min. and max. particle IDs for selection if desired, otherwise uses all 
+            min. and max. particle IDs for selection if desired, otherwise uses all
             particles of the specified type.
     use_guess : None or str ('previous')
-            specifies where the intial sphere is centered. None uses the com of 
+            specifies where the intial sphere is centered. None uses the com of
             every particle, 'previous' uses the previous snapshot's com.
     com_kwargs : dict, optional
             kwargs for snap.find_position_center, by default {}
@@ -91,3 +95,57 @@ def orbit_com(
         )
 
     return np.round(orbit, 6)
+
+
+def get_particle_orbit(sim_dir: str, part_type: int, ids: list) -> Orbit:
+    """
+    Stores the orbit of a particle or particles throughout a simulation.
+    TODO: support loading precomputed centers and rotations
+
+    Parameters
+    ----------
+    sim_dir : str
+        Directory containing simulation snapshots
+    part_type : int
+        Type of particle
+    ids : list
+        List of IDs of desired particles
+
+    Returns
+    -------
+    Orbit : snapanalysis.orbit.Orbit
+        Orbit object containing the orbits of the specified particles
+    """
+
+    snap_names = get_snaps(sim_dir)
+    N_snaps = len(snap_names)
+
+    times = np.zeros(N_snaps)
+    pos = np.zeros([N_snaps, 3, len(ids)])
+    vel = np.zeros([N_snaps, 3, len(ids)])
+
+    for i, snap_name in enumerate(snap_names):
+        s = snapshot(snap_name, part_type)
+        s.load_particle_data(["ParticleIDs", "Coordinates", "Velocities"])
+        s.find_and_apply_center()
+        s.align_angular_momentum()
+
+        mask = np.isin(s.data_fields["ParticleIDs"], ids)
+        s.select_particles(mask)
+        s.arrange_fields(np.argsort(s.data_fields["ParticleIDs"]))
+
+        times[i] = s.time.value
+        pos[i] = s.data_fields["Coordinates"].T.value
+        vel[i] = s.data_fields["Velocities"].T.value
+
+        if i == 0:
+            id_map = dict(
+                zip(
+                    s.data_fields["ParticleIDs"].value.astype(int).astype(str),
+                    range(len(ids)),
+                )
+            )
+
+    return Orbit(
+        times * s.time.unit, pos * s.length_unit, vel * s.vel_unit, id_map, sim_dir
+    )

--- a/src/snapanalysis/snap.py
+++ b/src/snapanalysis/snap.py
@@ -1,4 +1,4 @@
-# Contains the main snaphot class of snapAnalysis, which stores snapshots in a 
+# Contains the main snaphot class of snapAnalysis, which stores snapshots in a
 # flexible format.
 
 import numpy as np
@@ -15,8 +15,8 @@ from scipy.spatial import KDTree
 
 
 class snapshot:
-    """The main class of snapAnalysis, which reads and stores a single particle type 
-    from a single gagdet/arepo format hdf5 snapshot. Methods provide common analysis 
+    """The main class of snapAnalysis, which reads and stores a single particle type
+    from a single gagdet/arepo format hdf5 snapshot. Methods provide common analysis
     routines such as computing density fields, centering, rotations, etc.
     """
 
@@ -167,7 +167,7 @@ class snapshot:
         return masstable
 
     def check_if_field_read(self, field: str) -> bool:
-        """check_if_field_read checks to see whether a data field has 
+        """check_if_field_read checks to see whether a data field has
         already been stored
 
         Parameters
@@ -187,8 +187,8 @@ class snapshot:
         return True
 
     def arrange_fields(self, indices: np.ndarray) -> None:
-        """arrange_fields re-arranges all existing data fields according 
-        to the input indices. Useful for sorting the simulation by particle ID, 
+        """arrange_fields re-arranges all existing data fields according
+        to the input indices. Useful for sorting the simulation by particle ID,
         for instance.
 
         Parameters
@@ -217,9 +217,7 @@ class snapshot:
 
         if isinstance(selection, np.ndarray):
             if len(selection) != len(IDs):
-                raise ValueError(
-                    "Mask length must equal the number of particles!"
-                )
+                raise ValueError("Mask length must equal the number of particles!")
         elif not isinstance(selection, tuple):
             raise TypeError(
                 "Selection must be a tuple of min and max IDs or a boolean array mask"
@@ -291,7 +289,7 @@ class snapshot:
                 )
 
     def get_FDM_velocities(self) -> None:
-        """Calculates the FDM velocity field based on the wavefunction outputs, 
+        """Calculates the FDM velocity field based on the wavefunction outputs,
         via the phase gradient method:
         v = hbar/m gradient(phase). Based on code from Philip Mocz
         """
@@ -361,7 +359,7 @@ class snapshot:
     def apply_center(
         self, pos_center: np.ndarray, vel_center: np.ndarray | None = None
     ) -> None:
-        """center_particles centers particles on a specified center 
+        """center_particles centers particles on a specified center
         in position and velocity
 
         Parameters
@@ -394,19 +392,19 @@ class snapshot:
         N_min: int = 1000,
         verbose: bool = False,
     ) -> np.ndarray:
-        """find_position_center finds the center of mass of the snapshot via 
+        """find_position_center finds the center of mass of the snapshot via
         the shrinking-spheres method.
 
         Parameters
         ----------
         guess : None or np.ndarray, optional
-                Initial [x,y,z] guess for COM position. If None, uses the com of 
+                Initial [x,y,z] guess for COM position. If None, uses the com of
                 every active particle in the box.
         r_start : None or float, optional
-                Initial sphere radius, default (none) uses furthest particle from 
+                Initial sphere radius, default (none) uses furthest particle from
                 box origin
         vol_dec : float, optional
-                Factor by which the sphere radius is reduced during an iteration, 
+                Factor by which the sphere radius is reduced during an iteration,
                 by default 3.
         delta : float, optional
                 Tolerance, stop when change in COM is less than delta, by default 0.01
@@ -492,7 +490,7 @@ class snapshot:
         pos_center : np.ndarray
                 [x, y, z] center of mass position
         r_max : u.Quantity, optional
-                max distance from COM to use particles for the calculation, 
+                max distance from COM to use particles for the calculation,
                 by default 15.0*u.kpc
 
         Returns
@@ -516,7 +514,7 @@ class snapshot:
         self, com_kwargs: dict = {}, vel_kwargs: dict = {}
     ) -> None:
         """find_and_apply_center Calculates the positions and velocity center
-        of the snapshot and centers the particle data on the COM location 
+        of the snapshot and centers the particle data on the COM location
         in phase-space.
 
         Parameters
@@ -558,13 +556,13 @@ class snapshot:
     def find_angular_momentum_direction(
         self, r_max: u.Quantity | None = None
     ) -> np.ndarray:
-        """find_angular_momentum_direction Returns the normalized average 
+        """find_angular_momentum_direction Returns the normalized average
         specific angular momentum vector of the loaded particles.
 
         Parameters
         ----------
         r_max : u.Quantity | None, optional
-                max. radius within which to consider particles. None uses entire box. 
+                max. radius within which to consider particles. None uses entire box.
                 By default None
 
         Returns
@@ -601,7 +599,7 @@ class snapshot:
         self.apply_rotation(mat)
 
     def principal_axes(self) -> tuple[np.ndarray, np.ndarray]:
-        '''principal_axes calculates the length and direction of the principal
+        """principal_axes calculates the length and direction of the principal
         axes of the particle distribution by diagonalizing the inertia tensor.
 
         Returns
@@ -610,11 +608,10 @@ class snapshot:
             Principal axes lengths (eigenvalues of inertia tensor)
         np.ndarray
             Principal axes directions (eigenvectors of inertia tensor)
-        '''
+        """
         self.load_particle_data(["Masses", "Coordinates"])
         inertia_tensor = utils.inertia_tensor(
-            self.data_fields["Masses"].value, 
-            self.data_fields["Coordinates"].value
+            self.data_fields["Masses"].value, self.data_fields["Coordinates"].value
         )
         return np.linalg.eig(inertia_tensor)
 
@@ -628,7 +625,7 @@ class snapshot:
         slice_width: None | float = None,
         normalization: bool = "surface",
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """density_projection generates a density histogram projected along 
+        """density_projection generates a density histogram projected along
         the specified axis.
 
         Parameters
@@ -779,8 +776,8 @@ class snapshot:
         """density_points computes the local density field at a specified collection of
         points using the k_max-th nearest particles to the point.
 
-        In practice, the density at a local point is calculated as the mass of 
-        k_max particles, divided by the volume of a sphere with radius equal to the 
+        In practice, the density at a local point is calculated as the mass of
+        k_max particles, divided by the volume of a sphere with radius equal to the
         distance to the k_max-th nearest-neighbor.
 
         Parameters
@@ -788,13 +785,13 @@ class snapshot:
         points : np.ndarray
                 Nx3 array of points at which to compute the density
         k_max : int, optional
-                maximum nearest neighbor to use in density calculation, i.e. 
+                maximum nearest neighbor to use in density calculation, i.e.
                 the defualt of 1000 uses the 1000 nearest-neighbors.
 
         Returns
         -------
         np.ndarray
-                Array of length N containing the value of the density field at the 
+                Array of length N containing the value of the density field at the
                 input points
         """
 
@@ -824,7 +821,7 @@ class snapshot:
         plot: bool = True,
         plot_name: bool | str = False,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """anisotropy_profile calculates the velocity anisotropy profile of a halo, 
+        """anisotropy_profile calculates the velocity anisotropy profile of a halo,
         given by Eqn 4.61 of Binney & Tremaine
 
         Parameters
@@ -836,7 +833,7 @@ class snapshot:
         nbins : int, optional
                 number of radial bins, by default 100
         log_bins : bool, optional
-                If True, make logarithmically spaced bins instead of linearly 
+                If True, make logarithmically spaced bins instead of linearly
                 spaced bins, by default False
         plot : bool, optional
                 show a plot of the computed profile, by default True
@@ -916,7 +913,7 @@ class snapshot:
         plot_name: bool | str = False,
         slice_width: None | float = None,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """potential_projection bins the particles in the specified plane and finds 
+        """potential_projection bins the particles in the specified plane and finds
         the mean value of the potential within each bin.
 
         Parameters
@@ -924,15 +921,15 @@ class snapshot:
         axis : int, optional
                 Axis to project along (x=0, y=1, z=2), by default 2
         bins : int | list, optional
-                bin specification passed to scipy's binned_statistic_2d, 
+                bin specification passed to scipy's binned_statistic_2d,
                 by default [200,200]
         plot : bool, optional
                 create a plot of the potential, by default True
         plot_name : bool | str, optional
                 if not False, saves the plot under this file name, by default False
         slice_width : None | float, optional
-                Leave as None to use the whole box. Otherwise, provide a distance 
-                in the length units of the snapshot from the midplane along the 
+                Leave as None to use the whole box. Otherwise, provide a distance
+                in the length units of the snapshot from the midplane along the
                 specified axis to include, by default None
 
         Returns

--- a/src/snapanalysis/utils.py
+++ b/src/snapanalysis/utils.py
@@ -148,7 +148,7 @@ def cartesian_to_spherical(coords: np.ndarray) -> np.ndarray:
 
 
 def vector_cartesian_to_spherical(coords: np.ndarray, vecs: np.ndarray) -> np.ndarray:
-    '''vector_cartesian_to_spherical transforms a vector field defined in 
+    """vector_cartesian_to_spherical transforms a vector field defined in
     cartesian coordinates at coords with vectors vecs into spherical coordinates.
 
     Parameters
@@ -162,7 +162,7 @@ def vector_cartesian_to_spherical(coords: np.ndarray, vecs: np.ndarray) -> np.nd
     -------
     np.ndarray
         (r, theta (polar), phi (azimuth)) vectors
-    '''
+    """
 
     # make inputs 2D if required
     if coords.ndim == 1:
@@ -173,24 +173,24 @@ def vector_cartesian_to_spherical(coords: np.ndarray, vecs: np.ndarray) -> np.nd
         remove_axis = False
 
     coords_spherical = cartesian_to_spherical(coords)
-    theta = coords_spherical[:,1]
-    phi = coords_spherical[:,2]
+    theta = coords_spherical[:, 1]
+    phi = coords_spherical[:, 2]
 
-    vx = vecs[:,0]
-    vy = vecs[:,1]
-    vz = vecs[:,2]
+    vx = vecs[:, 0]
+    vy = vecs[:, 1]
+    vz = vecs[:, 2]
 
     v_r = (
-        np.sin(theta)*np.cos(phi)*vx
-        + np.sin(theta)*np.sin(phi)*vy
-        +  np.cos(theta)*vz
+        np.sin(theta) * np.cos(phi) * vx
+        + np.sin(theta) * np.sin(phi) * vy
+        + np.cos(theta) * vz
     )
     v_theta = (
-        np.cos(theta)*np.cos(phi)*vx 
-        + np.cos(theta)*np.sin(phi)*vy 
-        - np.sin(theta)*vz
+        np.cos(theta) * np.cos(phi) * vx
+        + np.cos(theta) * np.sin(phi) * vy
+        - np.sin(theta) * vz
     )
-    v_phi = (-np.sin(phi)*vx + np.cos(phi)*vy)
+    v_phi = -np.sin(phi) * vx + np.cos(phi) * vy
 
     if remove_axis:
         return np.hstack([v_r, v_theta, v_phi])
@@ -230,7 +230,7 @@ def cartesian_to_cylindrical(coords: np.ndarray) -> np.ndarray:
 
 
 def vector_cartesian_to_cylindrical(coords: np.ndarray, vecs: np.ndarray) -> np.ndarray:
-    '''vector_cartesian_to_cylindrical transforms a vector field defined in 
+    """vector_cartesian_to_cylindrical transforms a vector field defined in
     cartesian coordinates at coords with vectors vecs into cylindrical coordinates.
 
     Parameters
@@ -244,7 +244,7 @@ def vector_cartesian_to_cylindrical(coords: np.ndarray, vecs: np.ndarray) -> np.
     -------
     np.ndarray
         (rho, phi (azimuth), z) vectors
-    '''
+    """
 
     # make inputs 2D if required
     if coords.ndim == 1:
@@ -255,14 +255,14 @@ def vector_cartesian_to_cylindrical(coords: np.ndarray, vecs: np.ndarray) -> np.
         remove_axis = False
 
     coords_cylindrical = cartesian_to_cylindrical(coords)
-    phi = coords_cylindrical[:,1]
+    phi = coords_cylindrical[:, 1]
 
-    vx = vecs[:,0]
-    vy = vecs[:,1]
-    vz = vecs[:,2]
+    vx = vecs[:, 0]
+    vy = vecs[:, 1]
+    vz = vecs[:, 2]
 
-    v_rho = (np.cos(phi)*vx + np.sin(phi)*vy)
-    v_phi = (-np.sin(phi)*vx + np.cos(phi)*vy)
+    v_rho = np.cos(phi) * vx + np.sin(phi) * vy
+    v_phi = -np.sin(phi) * vx + np.cos(phi) * vy
 
     if remove_axis:
         return np.hstack([v_rho, v_phi, vz])
@@ -272,7 +272,7 @@ def vector_cartesian_to_cylindrical(coords: np.ndarray, vecs: np.ndarray) -> np.
 
 def rotation_matrix(alpha: float, beta: float, gamma: float) -> np.ndarray:
     """rotation_matrix returns the rotation matrix for a general intrinsic rotation
-    of yaw, pitch, roll (Tait-Bryan angles about z,y,x) alpha, beta, gamma, 
+    of yaw, pitch, roll (Tait-Bryan angles about z,y,x) alpha, beta, gamma,
     respectively.
 
     Parameters
@@ -335,7 +335,7 @@ def find_alignment_rotation(vec: np.ndarray) -> np.ndarray:
 
 
 def inertia_tensor(m: np.ndarray, pos: np.ndarray) -> np.ndarray:
-    '''inertia_tensor Calculates the inertia tensor for a collection
+    """inertia_tensor Calculates the inertia tensor for a collection
     of point masses of mass m at positions pos
 
     Parameters
@@ -349,16 +349,16 @@ def inertia_tensor(m: np.ndarray, pos: np.ndarray) -> np.ndarray:
     -------
     np.ndarray
         3x3 symmetric inertia tensor
-    '''
+    """
 
     inertia_tensor = np.zeros([3, 3])
 
-    inertia_tensor[0,0] = np.sum(m * (pos[:,1]**2 + pos[:,2]**2))
-    inertia_tensor[1,1] = np.sum(m * (pos[:,0]**2 + pos[:,2]**2))
-    inertia_tensor[2,2] = np.sum(m * (pos[:,0]**2 + pos[:,1]**2))
+    inertia_tensor[0, 0] = np.sum(m * (pos[:, 1] ** 2 + pos[:, 2] ** 2))
+    inertia_tensor[1, 1] = np.sum(m * (pos[:, 0] ** 2 + pos[:, 2] ** 2))
+    inertia_tensor[2, 2] = np.sum(m * (pos[:, 0] ** 2 + pos[:, 1] ** 2))
 
-    inertia_tensor[0,1] = inertia_tensor[1,0] = - np.sum(m * pos[:,0] * pos[:,1])
-    inertia_tensor[0,2] = inertia_tensor[2,0] = - np.sum(m * pos[:,0] * pos[:,2])
-    inertia_tensor[1,2] = inertia_tensor[2,1] = - np.sum(m * pos[:,1] * pos[:,2])
+    inertia_tensor[0, 1] = inertia_tensor[1, 0] = -np.sum(m * pos[:, 0] * pos[:, 1])
+    inertia_tensor[0, 2] = inertia_tensor[2, 0] = -np.sum(m * pos[:, 0] * pos[:, 2])
+    inertia_tensor[1, 2] = inertia_tensor[2, 1] = -np.sum(m * pos[:, 1] * pos[:, 2])
 
     return inertia_tensor

--- a/tests/snap_unit_test.py
+++ b/tests/snap_unit_test.py
@@ -37,9 +37,9 @@ def test_can_read_metadata(snap, expected, request):
 
 def test_unit_detection(dm_snap):
     print(dm_snap)
-     # define tolerance - 1 part in 1000 should account for rounding differences 
-     # between unit specification in astropy vs gadget
-    unit_tol = 1e-3 
+    # define tolerance - 1 part in 1000 should account for rounding differences
+    # between unit specification in astropy vs gadget
+    unit_tol = 1e-3
     assert (dm_snap.field_units["Coordinates"] - 1.0 * u.kpc) / (
         1.0 * u.kpc
     ) < unit_tol, "Length unit detection failed!"
@@ -82,12 +82,8 @@ def test_can_select_particles_with_boolean_mask(dm_snap):
     mask = np.array([False] * dm_snap.N)
     mask[1000:2000] = True
     dm_snap.select_particles(mask)
-    assert len(dm_snap.data_fields["ParticleIDs"]) == 1000, (
-        "Mask selection failed!"
-    )
-    assert dm_snap.data_fields["Coordinates"].shape[0] == 1000, (
-        "Mask selection failed!"
-    )
+    assert len(dm_snap.data_fields["ParticleIDs"]) == 1000, "Mask selection failed!"
+    assert dm_snap.data_fields["Coordinates"].shape[0] == 1000, "Mask selection failed!"
 
 
 def test_centering(dm_snap):
@@ -104,18 +100,16 @@ def test_centering(dm_snap):
 
 def test_density_points_returns_correct_central_density(dm_snap):
     k = 100
-    central_density = dm_snap.density_points(
-        np.zeros(3), k_max=k
-    )[0].value
+    central_density = dm_snap.density_points(np.zeros(3), k_max=k)[0].value
 
-    particle_radii = np.sqrt(np.sum(dm_snap.data_fields['Coordinates']**2, axis=1))
-    volume = 4.0 * np.pi / 3.0 * (np.partition(particle_radii, k-1)[k-1])**3
-    emp_density = (dm_snap.data_fields['Masses'][0] * k / volume).value
+    particle_radii = np.sqrt(np.sum(dm_snap.data_fields["Coordinates"] ** 2, axis=1))
+    volume = 4.0 * np.pi / 3.0 * (np.partition(particle_radii, k - 1)[k - 1]) ** 3
+    emp_density = (dm_snap.data_fields["Masses"][0] * k / volume).value
 
-    assert np.abs(central_density/emp_density - 1) < 1e-6
+    assert np.abs(central_density / emp_density - 1) < 1e-6
 
 
 def test_halo_axis_ratios_are_similar(dm_snap):
     axis_ratios, principal_axes = dm_snap.principal_axes()
 
-    assert np.all(np.abs(axis_ratios/axis_ratios.max() - 1) < 0.2)
+    assert np.all(np.abs(axis_ratios / axis_ratios.max() - 1) < 0.2)

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1,0 +1,37 @@
+# Unit tests for the Orbit dataclass
+import numpy as np
+from snapanalysis.orbit import Orbit, read_orbit_from_file
+import astropy.units as u
+import pytest
+
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    return tmp_path
+
+
+def test_orbit_object_initialized_correctly():
+    t = np.arange(10) * u.Myr
+    ids = {"1": 0}
+    pos = np.zeros([10, 3]) * u.kpc
+    vel = np.ones([10, 3]) * u.km / u.s
+    orb = Orbit(t=t, ids=ids, pos=pos, vel=vel)
+
+    assert np.array_equal(orb.t, t)
+    assert orb.ids == ids
+    assert np.array_equal(orb.pos, pos)
+    assert np.array_equal(orb.vel, vel)
+    assert orb.source_dir is None
+
+
+def test_read_orbit_from_file(temp_dir):
+    t = np.arange(10) * u.Myr
+    ids = {"1": 0}
+    pos = np.zeros([10, 3]) * u.kpc
+    vel = np.ones([10, 3]) * u.km / u.s
+    orb = Orbit(t=t, ids=ids, pos=pos, vel=vel)
+    orb.save(temp_dir / "temp_orb.pkl")
+
+    orb_read = read_orbit_from_file(temp_dir / "temp_orb.pkl")
+
+    assert orb == orb_read

--- a/tests/test_orbit_workflow.py
+++ b/tests/test_orbit_workflow.py
@@ -1,0 +1,51 @@
+# E2E test for a workflow for extracting individual particle orbits from a simulation
+import numpy as np
+from astropy import units as u
+import pytest
+
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    return tmp_path
+
+
+def test_orbit_workflow(temp_dir):
+    from snapanalysis.orbit import Orbit, read_orbit_from_file
+    from snapanalysis.sim import get_particle_orbit
+
+    # a user wants to extract the orbit of two particles from an entire simulation
+    sim_dir = "tests/example_snaps/"
+    orb = get_particle_orbit(sim_dir, 1, ids=[1, 2])
+
+    # The orbit object stores the simulation directory that it refers to
+    orb.source_dir == sim_dir
+
+    # They verify the orbit contains the correct particles,
+    # (i.e. ID 1 is the first particle, and ID 2 is the second)
+    assert orb.ids["1"] == 0
+    assert orb.ids["2"] == 1
+
+    # The time array contains the snapshot times for the entire simulation
+    assert np.allclose(orb.t.value, np.array([0.0, 0.19718176]))
+
+    # The position array contains the xyz coordinates at each time,
+    # i.e. has the shape (N_times, 3, N_particles)
+    assert orb.pos.shape == (2, 3, 2)
+
+    # The velocity array contains the xyz coordinates at each time,
+    # i.e. has the shape (N_times, 3, N_particles)
+    assert orb.vel.shape == (2, 3, 2)
+
+    # The units are stored correctly
+    assert orb.t.unit == u.Gyr
+    assert orb.pos.unit == u.kpc
+    assert orb.vel.unit == u.km / u.s
+
+    # Finally, they save the orbit to a file
+    orb.save(temp_dir / "test_particle_orbits.pkl")
+
+    # Later, they want to load the stored orbit file
+    orb_from_file = read_orbit_from_file(temp_dir / "test_particle_orbits.pkl")
+
+    assert isinstance(orb_from_file, Orbit)
+    assert orb == orb_from_file

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1,8 +1,8 @@
 # E2E tests for functions in snapAnalysis.sim
+import numpy as np
 
 
 def test_orbit_com():
-    import numpy as np
     from snapanalysis.sim import orbit_com
     import os
 
@@ -21,9 +21,9 @@ def test_orbit_com():
         ]
     )
 
-    # A user wants to determine the COM position and velocity of the dark matter 
+    # A user wants to determine the COM position and velocity of the dark matter
     # halo in the test simulation contained in tests/example_snaps.
-    # They specify a shrinking factor of 2, and save the COM data in a 
+    # They specify a shrinking factor of 2, and save the COM data in a
     # file called test_centers.txt
     test_file = "tests/test_centers.txt"
     orbit = orbit_com(
@@ -32,7 +32,7 @@ def test_orbit_com():
 
     assert np.allclose(orbit, TEST_ARR), "Orbit determination failed!"
 
-    # Later, they want to use the stored centers, so they load the orbit file 
+    # Later, they want to use the stored centers, so they load the orbit file
     # they saved earlier, and compare it to the output from the center finder.
     orbit_from_file = np.loadtxt(test_file)
 
@@ -40,3 +40,51 @@ def test_orbit_com():
 
     # cleanup
     os.remove("tests/test_centers.txt")
+
+
+def test_particle_orbit_extraction_returns_correct_data():
+    from snapanalysis.sim import get_particle_orbit
+
+    orbits = get_particle_orbit("tests/example_snaps/", 1, [1, 2])
+
+    assert orbits.source_dir == "tests/example_snaps/"
+
+    assert orbits.ids["1"] == 0
+    assert orbits.ids["2"] == 1
+
+    assert np.allclose(orbits.t.value, np.array([0.0, 0.19718176]))
+
+    assert np.allclose(
+        orbits.pos.value,
+        np.array(
+            [
+                [
+                    [-6.37767716, -67.28720821],
+                    [-1.31997945, 275.07242887],
+                    [-3.76567291, 11.24781486],
+                ],
+                [
+                    [-9.43083674, -58.93297116],
+                    [-15.3050804, 264.30005654],
+                    [6.45821875, 90.12003454],
+                ],
+            ]
+        ),
+    )
+    assert np.allclose(
+        orbits.vel.value,
+        np.array(
+            [
+                [
+                    [-101.31617369, 5.04129786],
+                    [-111.0747997, 14.59257077],
+                    [62.6801419, -9.44535906],
+                ],
+                [
+                    [44.51811798, 7.05256656],
+                    [-17.01287482, 14.23372224],
+                    [49.01288198, -3.34417125],
+                ],
+            ]
+        ),
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 import numpy as np
 import pytest
 
+
 def test_com_define() -> None:
     from snapanalysis.utils import com_define
 
@@ -69,13 +70,15 @@ def test_get_snaps() -> None:
     [
         (np.ones(3), np.array([np.sqrt(3), np.arccos(1.0 / np.sqrt(3)), np.pi / 4.0])),
         (
-            np.ones([2, 3]), 
-            np.vstack([
-                np.array([np.sqrt(3), np.arccos(1.0 / np.sqrt(3)), np.pi / 4.0]), 
-                np.array([np.sqrt(3), np.arccos(1.0 / np.sqrt(3)), np.pi / 4.0])
-            ])
-        )
-    ]
+            np.ones([2, 3]),
+            np.vstack(
+                [
+                    np.array([np.sqrt(3), np.arccos(1.0 / np.sqrt(3)), np.pi / 4.0]),
+                    np.array([np.sqrt(3), np.arccos(1.0 / np.sqrt(3)), np.pi / 4.0]),
+                ]
+            ),
+        ),
+    ],
 )
 def test_cartesian_to_spherical(input, expected) -> None:
     from snapanalysis.utils import cartesian_to_spherical
@@ -90,13 +93,15 @@ def test_cartesian_to_spherical(input, expected) -> None:
     [
         (np.ones(3), np.array([np.sqrt(2), np.pi / 4.0, 1.0])),
         (
-            np.ones([2, 3]), 
-            np.vstack([
-                np.array([np.sqrt(2), np.pi / 4.0, 1.0]), 
-                np.array([np.sqrt(2), np.pi / 4.0, 1.0])
-            ])
-        )
-    ]
+            np.ones([2, 3]),
+            np.vstack(
+                [
+                    np.array([np.sqrt(2), np.pi / 4.0, 1.0]),
+                    np.array([np.sqrt(2), np.pi / 4.0, 1.0]),
+                ]
+            ),
+        ),
+    ],
 )
 def test_cartesian_to_cylindrical(input, expected) -> None:
     from snapanalysis.utils import cartesian_to_cylindrical
@@ -122,22 +127,19 @@ def test_find_alignment_rotation() -> None:
 
 
 @pytest.mark.parametrize(
-    "input_points, input_vectors, expected", 
+    "input_points, input_vectors, expected",
     [
         (
-            np.array([0.5, 0.5, 1./np.sqrt(2)]), 
-            np.array([0., 0., 1.]), 
-            np.array([1./np.sqrt(2), -1./np.sqrt(2), 0])
+            np.array([0.5, 0.5, 1.0 / np.sqrt(2)]),
+            np.array([0.0, 0.0, 1.0]),
+            np.array([1.0 / np.sqrt(2), -1.0 / np.sqrt(2), 0]),
         ),
         (
-            np.array([[0.5, 0.5, 1./np.sqrt(2)],
-                     [1., 0., 0.]]), 
-            np.array([[0., 0., 1.],
-                     [0., 0., 1.]]), 
-            np.array([[1./np.sqrt(2), -1./np.sqrt(2), 0],
-                     [0., -1., 0.]])
-        )
-    ]
+            np.array([[0.5, 0.5, 1.0 / np.sqrt(2)], [1.0, 0.0, 0.0]]),
+            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+            np.array([[1.0 / np.sqrt(2), -1.0 / np.sqrt(2), 0], [0.0, -1.0, 0.0]]),
+        ),
+    ],
 )
 def test_vector_cartesian_to_spherical(input_points, input_vectors, expected) -> None:
     from snapanalysis.utils import vector_cartesian_to_spherical
@@ -148,23 +150,21 @@ def test_vector_cartesian_to_spherical(input_points, input_vectors, expected) ->
 
     return None
 
+
 @pytest.mark.parametrize(
-    "input_points, input_vectors, expected", 
+    "input_points, input_vectors, expected",
     [
         (
-            np.array([0.5, 0.5, 1.]), 
-            np.array([0., 0., 1.]), 
-            np.array([0., 0., 1.])
+            np.array([0.5, 0.5, 1.0]),
+            np.array([0.0, 0.0, 1.0]),
+            np.array([0.0, 0.0, 1.0]),
         ),
         (
-            np.array([[0.5, 0.5, 1.],
-                     [1., 0., 0.]]), 
-            np.array([[0., 0., 1.],
-                     [1., 0., 0.]]), 
-            np.array([[0., 0., 1.],
-                     [1., 0., 0.]])
-        )
-    ]
+            np.array([[0.5, 0.5, 1.0], [1.0, 0.0, 0.0]]),
+            np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]),
+            np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]),
+        ),
+    ],
 )
 def test_vector_cartesian_to_cylindrical(input_points, input_vectors, expected) -> None:
     from snapanalysis.utils import vector_cartesian_to_cylindrical
@@ -179,20 +179,11 @@ def test_vector_cartesian_to_cylindrical(input_points, input_vectors, expected) 
 def test_inertia_tensor_for_point_masses() -> None:
     from snapanalysis.utils import inertia_tensor
 
-    input_pos = np.array([
-        [-1., 0., 0.],
-        [1., 0., 0.],
-        [0, -1., 2.]
-    ])
-    input_m = np.array([1., 2., 1.])
+    input_pos = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0, -1.0, 2.0]])
+    input_m = np.array([1.0, 2.0, 1.0])
 
-    expected = np.array([
-        [5., 0., 0.],
-        [0., 7., 2.],
-        [0., 2., 4.]
-    ])
+    expected = np.array([[5.0, 0.0, 0.0], [0.0, 7.0, 2.0], [0.0, 2.0, 4.0]])
 
-    assert np.allclose(
-        inertia_tensor(input_m, input_pos), expected
-    ), "Inertia tensor calculation failed!"
-
+    assert np.allclose(inertia_tensor(input_m, input_pos), expected), (
+        "Inertia tensor calculation failed!"
+    )


### PR DESCRIPTION
Adds an Orbit dataclass to store the orbits of individual particles over the course of a simulation. Also adds functionality for constructing these given a simulation and a list of desired particles. 