### PR TITLE
simulation rotation calculation and orbit centering

### DIFF
--- a/src/snapanalysis/sim.py
+++ b/src/snapanalysis/sim.py
@@ -3,8 +3,9 @@
 # TODO: function for storing rotation matrices
 
 import numpy as np
+import astropy.units as u
 from .snap import snapshot
-from .utils import get_snaps
+from .utils import get_snaps, find_alignment_rotation
 from .orbit import Orbit
 
 
@@ -77,7 +78,7 @@ def orbit_com(
 
         orbit[i] = s.time.value, *tuple(com_p.value), *tuple(com_v.value)
 
-    if out_file:
+    if out_file is not None:
         np.savetxt(
             out_file,
             orbit,
@@ -97,7 +98,75 @@ def orbit_com(
     return np.round(orbit, 6)
 
 
-def get_particle_orbit(sim_dir: str, part_type: int, ids: list) -> Orbit:
+def get_alignment_rotations(
+    sim_dir: str,
+    part_type: int,
+    r_max: u.Quantity | None = None,
+    out_file: None | str = None,
+    use_centers: None | str = None,
+) -> np.ndarray:
+    """
+    Generates the rotation matrices needed to align the angular momentum vector of
+    the specified particle type to the z-axis for every snapshot in a simulation.
+
+    Parameters
+    ----------
+    sim_dir : str
+        Directory in which the simualtion snapshots are stored
+    part_type : int
+        Particle type with which to compute angular momentum vectors
+    r_max : u.Quantity | None, optional
+        If not None, computes angular momenta using only particles inside
+        this radius, by default None
+    out_file : None | str, optional
+        If given as a string, saves the rotation matrices to a numpy
+        binary file of this name, by default None
+    use_centers : None or str, optional
+        Uses COM positions and velocities stored in the specified text file. If None,
+        snapshots will be auto-centered before rotations are calculated
+
+    Returns
+    -------
+    np.ndarray
+        N_snapsx3x3 array containting the rotation matrices needed
+        to align each snapshot's angular momentum to the z-axis
+    """
+    snap_names = get_snaps(sim_dir)
+
+    if use_centers is not None:
+        centers = np.loadtxt(use_centers)
+
+    N_snaps = len(snap_names)
+    matrices = np.zeros([N_snaps, 3, 3])
+
+    for i, snap_name in enumerate(snap_names):
+        s = snapshot(snap_name, part_type)
+        s.load_particle_data(["Coordinates", "Velocities"])
+
+        if use_centers is not None:
+            s.apply_center(
+                pos_center=centers[i, 1:4] * s.length_unit,
+                vel_center=centers[i, 4:7] * s.vel_unit,
+            )
+        else:
+            s.find_and_apply_center()
+
+        J_vec = s.find_angular_momentum_direction(r_max)
+        matrices[i, :, :] = find_alignment_rotation(J_vec.value)
+
+    if out_file is not None:
+        np.save(out_file, matrices)
+
+    return matrices
+
+
+def get_particle_orbit(
+    sim_dir: str,
+    part_type: int,
+    ids: list,
+    use_centers: None | str = None,
+    use_rotations: None | str = None,
+) -> Orbit:
     """
     Stores the orbit of a particle or particles throughout a simulation.
     TODO: support loading precomputed centers and rotations
@@ -110,6 +179,12 @@ def get_particle_orbit(sim_dir: str, part_type: int, ids: list) -> Orbit:
         Type of particle
     ids : list
         List of IDs of desired particles
+    use_centers : None or str, optional
+        Uses COM positions and velocities stored in the specified text file. If None,
+        snapshots will be auto-centered
+    use_rotations : None or str, optional
+        Uses rotation matrices stored in the specified numpy binary file. If None,
+        snapshots will be auto-aligned
 
     Returns
     -------
@@ -120,6 +195,11 @@ def get_particle_orbit(sim_dir: str, part_type: int, ids: list) -> Orbit:
     snap_names = get_snaps(sim_dir)
     N_snaps = len(snap_names)
 
+    if use_centers is not None:
+        centers = np.loadtxt(use_centers)
+    if use_rotations is not None:
+        rotations = np.load(use_rotations)
+
     times = np.zeros(N_snaps)
     pos = np.zeros([N_snaps, 3, len(ids)])
     vel = np.zeros([N_snaps, 3, len(ids)])
@@ -127,8 +207,17 @@ def get_particle_orbit(sim_dir: str, part_type: int, ids: list) -> Orbit:
     for i, snap_name in enumerate(snap_names):
         s = snapshot(snap_name, part_type)
         s.load_particle_data(["ParticleIDs", "Coordinates", "Velocities"])
-        s.find_and_apply_center()
-        s.align_angular_momentum()
+        if use_centers is not None:
+            s.apply_center(
+                pos_center=centers[i, 1:4] * s.length_unit,
+                vel_center=centers[i, 4:7] * s.vel_unit,
+            )
+        else:
+            s.find_and_apply_center()
+        if use_rotations is not None:
+            s.apply_rotation(rotations[i, :, :])
+        else:
+            s.align_angular_momentum()
 
         mask = np.isin(s.data_fields["ParticleIDs"], ids)
         s.select_particles(mask)

--- a/tests/snap_unit_test.py
+++ b/tests/snap_unit_test.py
@@ -98,6 +98,27 @@ def test_centering(dm_snap):
     ), "Velocity center calculation failed!"
 
 
+def test_angular_momentum_alignment_is_consistent_with_manual_rotation(dm_snap):
+    from snapanalysis.utils import find_alignment_rotation
+
+    dm_snap.align_angular_momentum()
+    assert np.allclose(
+        dm_snap.find_angular_momentum_direction(), np.array([0.0, 0.0, 1.0])
+    )
+
+    snap_2 = snapshot("tests/example_snaps/snap_000.hdf5", 1)
+    J_vec = snap_2.find_angular_momentum_direction()
+    mat = find_alignment_rotation(J_vec.value)
+    snap_2.apply_rotation(mat)
+
+    assert np.allclose(
+        snap_2.find_angular_momentum_direction(), np.array([0.0, 0.0, 1.0])
+    )
+    assert np.allclose(
+        dm_snap.data_fields["Coordinates"], snap_2.data_fields["Coordinates"]
+    )
+
+
 def test_density_points_returns_correct_central_density(dm_snap):
     k = 100
     central_density = dm_snap.density_points(np.zeros(3), k_max=k)[0].value

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1,90 +1,121 @@
 # E2E tests for functions in snapAnalysis.sim
 import numpy as np
+from snapanalysis.sim import orbit_com, get_particle_orbit, get_alignment_rotations
+import pytest
 
-
-def test_orbit_com():
-    from snapanalysis.sim import orbit_com
-    import os
-
-    TEST_ARR = np.array(
+# expected particle orbit data
+PARTICLE_ORBIT_POS = np.array(
+    [
         [
-            [0.000000, 0.110668, -0.016284, 0.421207, -2.337177, -0.104841, -1.221633],
-            [
-                0.197182,
-                -0.401837,
-                -0.480167,
-                -0.274596,
-                -0.160502,
-                -0.603877,
-                -0.087050,
-            ],
-        ]
-    )
+            [-6.37767716, -67.28720821],
+            [-1.31997945, 275.07242887],
+            [-3.76567291, 11.24781486],
+        ],
+        [
+            [-9.43083674, -58.93297116],
+            [-15.3050804, 264.30005654],
+            [6.45821875, 90.12003454],
+        ],
+    ]
+)
 
+PARTICLE_ORBIT_VEL = np.array(
+    [
+        [
+            [-101.31617369, 5.04129786],
+            [-111.0747997, 14.59257077],
+            [62.6801419, -9.44535906],
+        ],
+        [
+            [44.51811798, 7.05256656],
+            [-17.01287482, 14.23372224],
+            [49.01288198, -3.34417125],
+        ],
+    ]
+)
+
+# expected snapshot orbit data
+COM_ORBIT = np.array(
+    [
+        [0.0, 0.122077, -0.062773, 0.174305, -2.467153, -0.026791, -1.192435],
+        [0.197182, -0.430234, -0.513655, -0.271056, -0.246454, -0.602834, -0.123797],
+    ],
+)
+
+# expected alignment rotation data
+ALIGN_ROT = np.array(
+    [
+        [
+            [-0.08363217, 0.0202638, -0.99629064],
+            [-0.23548298, -0.97187847, 0.0],
+            [-0.96827343, 0.23460949, 0.08605209],
+        ],
+        [
+            [-0.09203664, -0.00533282, -0.99574134],
+            [0.0578453, -0.99832556, 0.0],
+            [-0.99407403, -0.05759896, 0.09219101],
+        ],
+    ]
+)
+
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    return tmp_path
+
+
+def test_simulation_workflow(temp_dir):
     # A user wants to determine the COM position and velocity of the dark matter
     # halo in the test simulation contained in tests/example_snaps.
-    # They specify a shrinking factor of 2, and save the COM data in a
+    # They save the COM data in a
     # file called test_centers.txt
-    test_file = "tests/test_centers.txt"
-    orbit = orbit_com(
-        "tests/example_snaps/", 1, com_kwargs={"vol_dec": 2.0}, out_file=test_file
+    com_file = temp_dir / "test_centers.txt"
+    rot_file = temp_dir / "test_rotations.npy"
+    orbit = orbit_com("tests/example_snaps/", 1, out_file=com_file)
+
+    assert np.allclose(orbit, COM_ORBIT), "Orbit determination failed!"
+
+    # Next, they compute the rotation matrices required to align the
+    # angular momentum of the halo with the z-axis
+    rotations = get_alignment_rotations(
+        "tests/example_snaps/", 1, out_file=rot_file, use_centers=com_file
     )
 
-    assert np.allclose(orbit, TEST_ARR), "Orbit determination failed!"
+    assert np.allclose(rotations, ALIGN_ROT)
 
     # Later, they want to use the stored centers, so they load the orbit file
     # they saved earlier, and compare it to the output from the center finder.
-    orbit_from_file = np.loadtxt(test_file)
+    orbit_from_file = np.loadtxt(com_file)
 
-    assert np.allclose(orbit_from_file, TEST_ARR), "Orbit file failed!"
+    assert np.allclose(orbit_from_file, COM_ORBIT), "Orbit file failed!"
 
-    # cleanup
-    os.remove("tests/test_centers.txt")
+    # and they do the same with the rotations
+    rot_from_file = np.load(rot_file)
+    assert np.allclose(rot_from_file, ALIGN_ROT)
+
+    # Next, they want to use those precomputed centers to find the orbits of
+    # the first two particle IDs
+    particle_orbits = get_particle_orbit(
+        "tests/example_snaps/", 1, [1, 2], use_centers=com_file, use_rotations=rot_file
+    )
+
+    assert np.allclose(particle_orbits.pos.value, PARTICLE_ORBIT_POS)
+    assert np.allclose(particle_orbits.vel.value, PARTICLE_ORBIT_VEL)
 
 
 def test_particle_orbit_extraction_returns_correct_data():
-    from snapanalysis.sim import get_particle_orbit
-
+    # A user wants to extract the orbits of the first two particle IDs
     orbits = get_particle_orbit("tests/example_snaps/", 1, [1, 2])
 
+    # they verify the orbits come from the correct simulation
     assert orbits.source_dir == "tests/example_snaps/"
 
+    # contain the correct particles
     assert orbits.ids["1"] == 0
     assert orbits.ids["2"] == 1
 
     assert np.allclose(orbits.t.value, np.array([0.0, 0.19718176]))
 
-    assert np.allclose(
-        orbits.pos.value,
-        np.array(
-            [
-                [
-                    [-6.37767716, -67.28720821],
-                    [-1.31997945, 275.07242887],
-                    [-3.76567291, 11.24781486],
-                ],
-                [
-                    [-9.43083674, -58.93297116],
-                    [-15.3050804, 264.30005654],
-                    [6.45821875, 90.12003454],
-                ],
-            ]
-        ),
-    )
-    assert np.allclose(
-        orbits.vel.value,
-        np.array(
-            [
-                [
-                    [-101.31617369, 5.04129786],
-                    [-111.0747997, 14.59257077],
-                    [62.6801419, -9.44535906],
-                ],
-                [
-                    [44.51811798, 7.05256656],
-                    [-17.01287482, 14.23372224],
-                    [49.01288198, -3.34417125],
-                ],
-            ]
-        ),
-    )
+    # and the correct data
+    assert np.allclose(orbits.pos.value, PARTICLE_ORBIT_POS)
+    assert np.allclose(orbits.vel.value, PARTICLE_ORBIT_VEL)


### PR DESCRIPTION
Add snapanalysis.sim.get_alignment_rotations() to store rotation matrices for an entire simulation. Also add the ability to calculate particle orbits with precomputed centers. 