### PR TITLE
Use pathlib to fix trailing slash behavior in get_snaps

### DIFF
--- a/src/snapanalysis/utils.py
+++ b/src/snapanalysis/utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 from glob import glob
 import re
-
+from pathlib import Path
 
 def com_define(m: np.ndarray, pos: np.ndarray) -> np.ndarray:
     """com_define basic center-of-mass calculation
@@ -97,7 +97,8 @@ def get_snaps(dir: str, ext: str = ".hdf5", prefix: str = "snap_") -> np.ndarray
             Ordered list of snapshots
     """
 
-    snap_list = np.array(glob(dir + prefix + "*" + ext))
+    sim_dir = Path(dir)
+    snap_list = np.array(glob(str(sim_dir / (prefix + "*" + ext))))
     nsnaps = len(snap_list)
 
     if nsnaps == 0:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,15 +51,23 @@ def test_get_vslice_indices() -> None:
 
     return None
 
-
-def test_get_snaps() -> None:
+# test get_snaps both with and without the trailing slash on the 
+# input path, since users may input either
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (CDM_TEST_SNAP_PATH, np.array(
+            [CDM_TEST_SNAP_PATH + "snap_000.hdf5", CDM_TEST_SNAP_PATH + "snap_001.hdf5"]
+        )),
+        (CDM_TEST_SNAP_PATH[:-1], np.array(
+            [CDM_TEST_SNAP_PATH + "snap_000.hdf5", CDM_TEST_SNAP_PATH + "snap_001.hdf5"]
+        ))
+    ]
+)
+def test_get_snaps(input, expected) -> None:
     from snapanalysis.utils import get_snaps
 
-    expected = np.array(
-        [CDM_TEST_SNAP_PATH + "snap_000.hdf5", CDM_TEST_SNAP_PATH + "snap_001.hdf5"]
-    )
-
-    assert np.array_equal(get_snaps(CDM_TEST_SNAP_PATH), expected), (
+    assert np.array_equal(get_snaps(input), expected), (
         "Snapshot collection failed!"
     )
 


### PR DESCRIPTION
Fixes issue #30 

Parameterized the test for get_snaps to check input directories with and without a trailing slash. This reproduced the behavior noted in issue #30. 

Solved by using pathlib to handle the construction of the glob string in get_snaps. 